### PR TITLE
revert fefd88c77853e7c71e1be5e5ca19e02e00521f47 

### DIFF
--- a/server/e2e/src/main/kotlin/org/jetbrains/bsp/bazel/BazelBspSampleRepoTest.kt
+++ b/server/e2e/src/main/kotlin/org/jetbrains/bsp/bazel/BazelBspSampleRepoTest.kt
@@ -586,7 +586,9 @@ object BazelBspSampleRepoTest : BazelBspTestBaseScenario() {
     val targetWithDependencyJavaBinary =
       DependencySourcesItem(
         BuildTargetIdentifier("$targetPrefix//target_with_dependency:java_binary"),
-        emptyList(),
+        listOf(
+          "file://\$BAZEL_OUTPUT_BASE_PATH/external/guava/guava-28.0-jre-src.jar",
+        ),
       )
     val javaTargetsSubpackageJavaLibrary =
       DependencySourcesItem(

--- a/server/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/bsp/BspRequestsRunner.kt
+++ b/server/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/bsp/BspRequestsRunner.kt
@@ -98,7 +98,7 @@ class BspRequestsRunner(private val serverLifetime: BazelBspServerLifetime) {
   }
 
   private fun <T> success(methodName: String, response: T): CompletableFuture<T> {
-    LOGGER.info("{} call finishing successfully", methodName)
+    LOGGER.info("{} call finishing successfully with response: {}", methodName, response)
     return CompletableFuture.completedFuture(response)
   }
 

--- a/server/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/sync/languages/java/JavaLanguagePlugin.kt
+++ b/server/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/sync/languages/java/JavaLanguagePlugin.kt
@@ -3,9 +3,12 @@ package org.jetbrains.bsp.bazel.server.sync.languages.java
 import ch.epfl.scala.bsp4j.BuildTarget
 import ch.epfl.scala.bsp4j.BuildTargetDataKind
 import ch.epfl.scala.bsp4j.JvmBuildTarget
+import org.jetbrains.bsp.bazel.info.BspTargetInfo.FileLocation
+import org.jetbrains.bsp.bazel.info.BspTargetInfo.JvmOutputsOrBuilder
 import org.jetbrains.bsp.bazel.info.BspTargetInfo.JvmTargetInfo
 import org.jetbrains.bsp.bazel.info.BspTargetInfo.TargetInfo
 import org.jetbrains.bsp.bazel.server.dependencygraph.DependencyGraph
+import org.jetbrains.bsp.bazel.server.model.Label
 import org.jetbrains.bsp.bazel.server.paths.BazelPathsResolver
 import org.jetbrains.bsp.bazel.server.sync.languages.JVMLanguagePluginParser
 import org.jetbrains.bsp.bazel.server.sync.languages.LanguagePlugin
@@ -53,7 +56,23 @@ class JavaLanguagePlugin(
   private fun getJdk(): Jdk = jdk ?: throw RuntimeException("Failed to resolve JDK for project")
 
   override fun dependencySources(targetInfo: TargetInfo, dependencyGraph: DependencyGraph): Set<URI> =
-    emptySet() // Provided via workspace/libraries
+    targetInfo.getJvmTargetInfoOrNull()?.run {
+      dependencyGraph
+        .transitiveDependenciesWithoutRootTargets(Label.parse(targetInfo.id))
+        .flatMap(::getSourceJars)
+        .map(bazelPathsResolver::resolveUri)
+        .toSet()
+    }.orEmpty()
+
+  private fun getSourceJars(targetInfo: TargetInfo): List<FileLocation> =
+    targetInfo
+      .getJvmTargetInfoOrNull()
+      ?.run { jarsOrBuilderList + generatedJarsList }
+      ?.flatMap(JvmOutputsOrBuilder::getSourceJarsList)
+      .orEmpty()
+
+  private fun TargetInfo.getJvmTargetInfoOrNull(): JvmTargetInfo? =
+    this.takeIf(TargetInfo::hasJvmTargetInfo)?.jvmTargetInfo
 
   override fun applyModuleData(moduleData: JavaModule, buildTarget: BuildTarget) {
     val jvmBuildTarget = toJvmBuildTarget(moduleData)


### PR DESCRIPTION
So, it looks like someone removed support for the dependency sources in favor of a proposed bsp api feature. I just literally reverted the commit and it seems to have fixed go to definition for external libraries. Primary: @jadenPete 