### PR TITLE
Rferguson fix diagnostics

### DIFF
--- a/server/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/bsp/managers/BazelBspCompilationManager.kt
+++ b/server/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/bsp/managers/BazelBspCompilationManager.kt
@@ -1,5 +1,7 @@
 package org.jetbrains.bsp.bazel.server.bsp.managers
 
+import ch.epfl.scala.bsp4j.TextDocumentIdentifier
+import java.nio.file.Path
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.runBlocking
@@ -7,16 +9,17 @@ import org.eclipse.lsp4j.jsonrpc.CancelChecker
 import org.jetbrains.bsp.bazel.bazelrunner.BazelRunner
 import org.jetbrains.bsp.bazel.server.bep.BepServer
 import org.jetbrains.bsp.bazel.server.diagnostics.DiagnosticsService
+import org.jetbrains.bsp.bazel.server.model.Label
 import org.jetbrains.bsp.bazel.server.paths.BazelPathsResolver
 import org.jetbrains.bsp.bazel.workspacecontext.TargetsSpec
 import org.jetbrains.bsp.protocol.JoinedBuildClient
-import java.nio.file.Path
 
 // TODO: remove this file once we untangle the spaghetti and use the method from ExecuteService
 
 class BazelBspCompilationManager(
   private val bazelRunner: BazelRunner,
   private val bazelPathsResolver: BazelPathsResolver,
+  private val hasAnyProblems: MutableMap<Label, Set<TextDocumentIdentifier>>,
   val client: JoinedBuildClient,
   val workspaceRoot: Path,
 ) {
@@ -28,7 +31,7 @@ class BazelBspCompilationManager(
     environment: List<Pair<String, String>> = emptyList(),
   ): BepBuildResult {
     val target = targetSpecs.values.firstOrNull()
-    val diagnosticsService = DiagnosticsService(workspaceRoot)
+    val diagnosticsService = DiagnosticsService(workspaceRoot, hasAnyProblems = hasAnyProblems)
     val bepServer = BepServer(client, diagnosticsService, originId, target, bazelPathsResolver)
     val bepReader = BepReader(bepServer)
     return try {

--- a/server/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/diagnostics/CompilerDiagnosticParser.kt
+++ b/server/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/diagnostics/CompilerDiagnosticParser.kt
@@ -1,9 +1,7 @@
 package org.jetbrains.bsp.bazel.server.diagnostics
 
 import ch.epfl.scala.bsp4j.DiagnosticSeverity
-import org.apache.logging.log4j.LogManager
 
-private val LOGGER = LogManager.getLogger("CompilerDiagnosticParser")
 
 object CompilerDiagnosticParser : Parser {
   override fun tryParse(output: Output): List<Diagnostic> = listOfNotNull(tryParseOne(output))
@@ -24,7 +22,6 @@ object CompilerDiagnosticParser : Parser {
       """.toRegex(RegexOption.COMMENTS)
 
   fun tryParseOne(output: Output): Diagnostic? {
-    LOGGER.info("Checking output:\n${output.peek()}")
      return output
       .tryTake(DiagnosticHeader)
       ?.let { match ->
@@ -34,7 +31,6 @@ object CompilerDiagnosticParser : Parser {
         val column = match.groups["columnNumber"]?.value?.toIntOrNull() ?: tryFindColumnNumber(messageLines) ?: 1
         val levelText = (match.groups["logLevel"]?.value ?: match.groups["errorLevel"]?.value ?: "").lowercase()
         val level = if (levelText == "warning") DiagnosticSeverity.WARNING else DiagnosticSeverity.ERROR
-        //val level = if (match.groupValues[5] == "warning") DiagnosticSeverity.WARNING else DiagnosticSeverity.ERROR
         val message = messageLines.joinToString("\n")
         Diagnostic(Position(line, column), message, path, output.targetLabel, level)
       }

--- a/server/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/diagnostics/CompilerDiagnosticParser.kt
+++ b/server/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/diagnostics/CompilerDiagnosticParser.kt
@@ -1,6 +1,9 @@
 package org.jetbrains.bsp.bazel.server.diagnostics
 
 import ch.epfl.scala.bsp4j.DiagnosticSeverity
+import org.apache.logging.log4j.LogManager
+
+private val LOGGER = LogManager.getLogger("CompilerDiagnosticParser")
 
 object CompilerDiagnosticParser : Parser {
   override fun tryParse(output: Output): List<Diagnostic> = listOfNotNull(tryParseOne(output))
@@ -9,28 +12,33 @@ object CompilerDiagnosticParser : Parser {
   // server/DiagnosticsServiceTest.kt:12:18: error: type mismatch: inferred type is String but Int was expected
   private val DiagnosticHeader =
     """
-      ^                # start of line
-      ([^:]+)          # file path (1)
-      :(\d+)           # line number (2)
-      (?::(\d+))?      # optional column number (3)
-      :\               # ": " separator
-      ([a-zA-Z\ ]+):\  # level (4)
-      (.*)             # actual error message (5)
+      ^                       # start of line
+      (?<logLevel>\[.*\]\s*)? #optional
+      (?<filePath>[^:]+)      # file path (2)
+      :(?<lineNumber>\d+)     # line number (3)
+      (?::(?<columnNumber>\d+))?      # optional column number (4)
+      (?::\ )?                # ": " separator
+      (?:(?<errorLevel>[a-zA-Z\ ]+):\ )? # optional level (5) could have been at the beginning instead
+      (?<errorMessage>.*)             # actual error message (6)
       $                # end of line
       """.toRegex(RegexOption.COMMENTS)
 
-  fun tryParseOne(output: Output): Diagnostic? =
-    output
+  fun tryParseOne(output: Output): Diagnostic? {
+    LOGGER.info("Checking output:\n${output.peek()}")
+     return output
       .tryTake(DiagnosticHeader)
       ?.let { match ->
-        val path = match.groupValues[1]
-        val line = match.groupValues[2].toInt()
-        val messageLines = collectMessageLines(match.groupValues[5], output)
-        val column = match.groupValues[3].toIntOrNull() ?: tryFindColumnNumber(messageLines) ?: 1
-        val level = if (match.groupValues[4] == "warning") DiagnosticSeverity.WARNING else DiagnosticSeverity.ERROR
+        val path = match.groups["filePath"]?.value ?: ""
+        val line = match.groups["lineNumber"]?.value?.toIntOrNull() ?: -1
+        val messageLines = collectMessageLines(match.groups["errorMessage"]?.value ?: "", output)
+        val column = match.groups["columnNumber"]?.value?.toIntOrNull() ?: tryFindColumnNumber(messageLines) ?: 1
+        val levelText = (match.groups["logLevel"]?.value ?: match.groups["errorLevel"]?.value ?: "").lowercase()
+        val level = if (levelText == "warning") DiagnosticSeverity.WARNING else DiagnosticSeverity.ERROR
+        //val level = if (match.groupValues[5] == "warning") DiagnosticSeverity.WARNING else DiagnosticSeverity.ERROR
         val message = messageLines.joinToString("\n")
         Diagnostic(Position(line, column), message, path, output.targetLabel, level)
       }
+    }
 
   private fun collectMessageLines(header: String, output: Output): List<String> {
     val lines = mutableListOf<String>()

--- a/server/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/diagnostics/DiagnosticsParser.kt
+++ b/server/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/diagnostics/DiagnosticsParser.kt
@@ -3,13 +3,13 @@ package org.jetbrains.bsp.bazel.server.diagnostics
 import org.jetbrains.bsp.bazel.server.model.Label
 
 interface DiagnosticsParser {
-  fun parse(bazelOutput: String, target: Label): List<Diagnostic>
+  fun parse(bazelOutput: String, target: Label, onlyKnownFiles: Boolean): List<Diagnostic>
 }
 
 class DiagnosticsParserImpl : DiagnosticsParser {
-  override fun parse(bazelOutput: String, target: Label): List<Diagnostic> {
+  override fun parse(bazelOutput: String, target: Label, onlyKnownFiles: Boolean): List<Diagnostic> {
     val output = prepareOutput(bazelOutput, target)
-    val diagnostics = collectDiagnostics(output)
+    val diagnostics = collectDiagnostics(output, onlyKnownFiles)
     return deduplicate(diagnostics)
   }
 
@@ -19,7 +19,7 @@ class DiagnosticsParserImpl : DiagnosticsParser {
     return Output(relevantLines, target)
   }
 
-  private fun collectDiagnostics(output: Output): List<Diagnostic> {
+  private fun collectDiagnostics(output: Output, onlyKnownFiles: Boolean): List<Diagnostic> {
     val diagnostics = mutableListOf<Diagnostic>()
     while (output.nonEmpty()) {
       for (parser in Parsers) {
@@ -31,7 +31,7 @@ class DiagnosticsParserImpl : DiagnosticsParser {
       }
     }
 
-    if (diagnostics.isEmpty()) {
+    if (diagnostics.isEmpty() && !onlyKnownFiles) {
       diagnostics.add(
         Diagnostic(
           position = Position(0, 0),

--- a/server/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/diagnostics/DiagnosticsService.kt
+++ b/server/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/diagnostics/DiagnosticsService.kt
@@ -1,21 +1,61 @@
 package org.jetbrains.bsp.bazel.server.diagnostics
 
+import ch.epfl.scala.bsp4j.BuildTargetIdentifier
 import ch.epfl.scala.bsp4j.PublishDiagnosticsParams
+import ch.epfl.scala.bsp4j.TextDocumentIdentifier
 import org.jetbrains.bsp.bazel.server.model.Label
 import java.nio.file.Path
+import java.util.Collections
 
 class DiagnosticsService(
   workspaceRoot: Path,
   private val parser: DiagnosticsParser = DiagnosticsParserImpl(),
   private val mapper: DiagnosticBspMapper = DiagnosticBspMapper(workspaceRoot),
+  private val hasAnyProblems: MutableMap<Label, Set<TextDocumentIdentifier>>, 
 ) {
+
+  private val updatedInThisRun = mutableSetOf<PublishDiagnosticsParams>()
+
+  val bspState: Map<Label, Set<TextDocumentIdentifier>>
+    get() = Collections.unmodifiableMap(hasAnyProblems)
+
   fun extractDiagnostics(
     bazelOutput: String,
     targetLabel: Label,
     originId: String?,
+    diagnosticsFromProgress: Boolean,
   ): List<PublishDiagnosticsParams> {
-    val parsedDiagnostics = parser.parse(bazelOutput, targetLabel)
+    val parsedDiagnostics = parser.parse(bazelOutput, targetLabel, diagnosticsFromProgress)
     val events = mapper.createDiagnostics(parsedDiagnostics, originId)
+    if (diagnosticsFromProgress) updatedInThisRun.addAll(events)
+    updateProblemState(events)
     return events
+  }
+
+  fun clearFormerDiagnostics(targetLabel: Label): List<PublishDiagnosticsParams> {
+    val docs = hasAnyProblems[targetLabel]
+    hasAnyProblems.remove(targetLabel)
+    val toClear =
+      if (updatedInThisRun.isNotEmpty()) {
+        val updatedDocs = updatedInThisRun.map { it.textDocument }.toSet()
+        hasAnyProblems[targetLabel] = updatedDocs
+        updatedInThisRun.clear()
+        docs?.subtract(updatedDocs)
+      } else {
+        docs
+      }
+    return toClear
+      ?.map { PublishDiagnosticsParams(it, BuildTargetIdentifier(targetLabel.value), emptyList(), true) }
+      .orEmpty()
+  }
+  private fun updateProblemState(events: List<PublishDiagnosticsParams>) {
+    events
+      .groupBy { it.buildTarget.uri }
+      .forEach { group ->
+        val buildTarget = Label.parse(group.key)
+        val params = group.value
+        val docs = params.map { it.textDocument }.toSet()
+        hasAnyProblems[buildTarget] = docs
+      }
   }
 }


### PR DESCRIPTION
I updated the regex that parses diagnostic messages to match ours. It should still match whatever it was matching before. I also restored functionality lost here: https://github.com/JetBrains/hirschgarten/commit/1227a5f7aae8d872687cbb9fdfe4284c9a76ff7f?w=1#diff-0d2ac579c3ed626e398d284da7089bbc557118d954035ac0fa503b15a15e5368L193
To be honest, I don't understand why it was removed in the first place, but this seems to fix diagnostics, specifically clearing diagnostics once the build is happy again. 