### PR TITLE
add support for lucidsoftware/rules_scala

### DIFF
--- a/server/aspects/rules/scala/scala_info.bzl
+++ b/server/aspects/rules/scala/scala_info.bzl
@@ -1,5 +1,9 @@
 load("//aspects:utils/utils.bzl", "file_location", "is_external", "map", "update_sync_output_groups")
 
+MAINLINE_SCALA_TOOLCHAIN = "@io_bazel_rules_scala//scala:toolchain_type"
+ANNEX_SCALA_TOOLCHAIN = "@rules_scala_annex//rules/scala:toolchain_type"
+
+
 SCALA_COMPILER_NAMES = [
     "scala3-compiler",
     "scala-compiler",
@@ -48,31 +52,62 @@ def extract_scalatest_classpath(rule_attr):
         extract_from_attr("_scalatest_reporter")
     )
 
-def extract_scala_info(target, ctx, output_groups, **kwargs):
+def extract_scala_info_mainline(target, ctx, output_groups):
+    scala_info = {}
+    rule_attr = ctx.rule.attr
+    common_scalac_opts = ctx.toolchains[MAINLINE_SCALA_TOOLCHAIN].scalacopts
+    if hasattr(rule_attr, "_scalac"):
+        scalac = rule_attr._scalac
+        compiler_classpath = find_scalac_classpath(scalac.default_runfiles.files.to_list())
+        if compiler_classpath:
+            scala_info["compiler_classpath"] = map(file_location, compiler_classpath)
+            if is_external(scalac):
+                update_sync_output_groups(output_groups, "bsp-sync-artifact", depset(compiler_classpath))
+    scala_info["scalac_opts"] = common_scalac_options + getattr(ctx.rule.attr, "scalacopts", [])
+    scala_info["scalatest_classpath"] = extract_scalatest_classpath(ctx.rule.attr)
+    return scala_info
+    
+def extract_scala_info_annex(target, ctx, output_groups):
+    scala_info = {}
+    rule_attr = ctx.rule.attr
+    scala_configuration = ctx.toolchains[SCALA_TOOLCHAIN].scala_configuration
+    common_scalac_options = scala_configuration.global_scalacopts
+
+    classpath_files = []
+    for target in scala_configuration.compiler_classpath:
+        for file in target[JavaInfo].runtime_output_jars:
+            classpath_files.append(file)
+    compiler_classpath = find_scalac_classpath(classpath_files)
+
+    if len(compiler_classpath) > 0:
+        scala_info["compiler_classpath"] = map(file_location, compiler_classpath)
+
+        if any([is_external(target) for target in scala_configuration.compiler_classpath]):
+            update_sync_output_groups(
+                output_groups,
+                "external-deps-resolve",
+                depset(compiler_classpath)
+            )
+
+    scala_info["scalac_opts"] = common_scalac_options + getattr(ctx.rule.attr, "scalacopts", [])
+    scala_info["scalatest_classpath"] = extract_scalatest_classpath(ctx.rule.attr)
+    return scala_info
+
+def extract_scala_info(target, ctx, output_groups):
     kind = ctx.rule.kind
     if not kind.startswith("scala_") and not kind.startswith("thrift_"):
         return None, None
-
-    SCALA_TOOLCHAIN = "@io_bazel_rules_scala//scala:toolchain_type"
-
-    scala_info = {}
 
     rule_attr = ctx.rule.attr
 
     # check of _scala_toolchain is necessary, because SCALA_TOOLCHAIN will always be present
     if hasattr(rule_attr, "_scala_toolchain"):
-        common_scalac_opts = ctx.toolchains[SCALA_TOOLCHAIN].scalacopts
-        if hasattr(rule_attr, "_scalac"):
-            scalac = rule_attr._scalac
-            compiler_classpath = find_scalac_classpath(scalac.default_runfiles.files.to_list())
-            if compiler_classpath:
-                scala_info["compiler_classpath"] = map(file_location, compiler_classpath)
-                if is_external(scalac):
-                    update_sync_output_groups(output_groups, "bsp-sync-artifact", depset(compiler_classpath))
+        scala_info = extract_scala_info_mainline(target, ctx, output_groups)
+    elif ANNEX_SCALA_TOOLCHAIN in ctx.toolchains:
+        scala_info = extract_scala_info_annex(target, ctx, output_groups)
     else:
-        common_scalac_opts = []
-    scala_info["scalac_opts"] = common_scalac_opts + getattr(ctx.rule.attr, "scalacopts", [])
-
-    scala_info["scalatest_classpath"] = extract_scalatest_classpath(rule_attr)
+        scala_info = {}
+        scala_info["scalac_opts"] =  getattr(ctx.rule.attr, "scalacopts", [])
+        scala_info["scalatest_classpath"] = extract_scalatest_classpath(rule_attr)
 
     return dict(scala_target_info = struct(**scala_info)), None

--- a/server/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/bsp/managers/BazelBspAspectsManager.kt
+++ b/server/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/bsp/managers/BazelBspAspectsManager.kt
@@ -73,7 +73,7 @@ class BazelBspAspectsManager(
   fun generateAspectsFromTemplates(
     ruleLanguages: List<RuleLanguage>,
     workspaceContext: WorkspaceContext,
-    toolchains: Map<RuleLanguage, Label?>,
+    toolchains: Map<RuleLanguage, List<Label>>,
     bazelRelease: BazelRelease,
     repoMapping: RepoMapping,
   ) {
@@ -97,7 +97,9 @@ class BazelBspAspectsManager(
           "javaEnabled" to javaEnabled.toString(),
           "pythonEnabled" to pythonEnabled.toString(),
           "bazel8OrAbove" to bazel8OrAbove.toString(),
-          "toolchainType" to ruleLanguage?.let { rl -> toolchains[rl]?.toString()?.let { "\"" + it + "\"" } },
+          // This will only return the first toolchain in the list.
+          // At the moment, there is only one place this is used, and it wouldn't make sense for there to be more than one anyway though.
+          "toolchainType" to ruleLanguage?.let { rl -> toolchains[rl]?.firstOrNull?.toString().let { "\"" + it + "\"" } },
         )
       templateWriter.writeToFile(templateFilePath, outputFile, variableMap)
     }
@@ -156,7 +158,12 @@ class BazelBspAspectsManager(
     val allowManualTargetsSyncFlags = if (shouldSyncManualFlags) listOf(buildManualTests()) else emptyList()
     val syncFlags = workspaceContextProvider.currentWorkspaceContext().syncFlags.values
 
-    val flagsToUse = defaultFlags + allowManualTargetsSyncFlags + syncFlags
+    /*
+     * Explicitly specifying a list of output groups should prevent bazel from building the default output group, but it will still include the validations output group unless you specifically exclude it.
+     * If the validations output group depends on the results of other more costly actions, they can make this take a long time.
+     * https://bazel.build/extending/rules#validation_actions
+     */
+    val flagsToUse = defaultFlags + allowManualTargetsSyncFlags + syncFlags + listOf("--norun_validations")
 
     return bazelBspCompilationManager
       .buildTargetsWithBep(

--- a/server/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/bsp/managers/BazelBspLanguageExtensionsGenerator.kt
+++ b/server/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/bsp/managers/BazelBspLanguageExtensionsGenerator.kt
@@ -60,12 +60,12 @@ class BazelBspLanguageExtensionsGenerator(internalAspectsResolver: InternalAspec
     return props
   }
 
-  fun generateLanguageExtensions(ruleLanguages: List<RuleLanguage>, toolchains: Map<RuleLanguage, Label?>) {
+  fun generateLanguageExtensions(ruleLanguages: List<RuleLanguage>, toolchains: Map<RuleLanguage, List<Label>>) {
     val fileContent = prepareFileContent(ruleLanguages, toolchains)
     createNewExtensionsFile(fileContent)
   }
 
-  private fun prepareFileContent(ruleLanguages: List<RuleLanguage>, toolchains: Map<RuleLanguage, Label?>) =
+  private fun prepareFileContent(ruleLanguages: List<RuleLanguage>, toolchains: Map<RuleLanguage, List<Label>>) =
     listOf(
       "# This is a generated file, do not edit it",
       createLoadStatementsString(ruleLanguages.map { it.language }),
@@ -86,9 +86,10 @@ class BazelBspLanguageExtensionsGenerator(internalAspectsResolver: InternalAspec
     return functionNames.joinToString(prefix = "EXTENSIONS = [\n", postfix = "\n]", separator = ",\n ") { "\t$it" }
   }
 
-  private fun createToolchainListString(ruleLanguages: List<RuleLanguage>, toolchains: Map<RuleLanguage, Label?>): String =
+  private fun createToolchainListString(ruleLanguages: List<RuleLanguage>, toolchains: Map<RuleLanguage, List<Label>>): String =
     ruleLanguages
       .mapNotNull { toolchains[it] }
+      .flatten()
       .joinToString(prefix = "TOOLCHAINS = [\n", postfix = "\n]", separator = ",\n ") { "\t\"$it\"" }
 
   private fun createNewExtensionsFile(fileContent: String) {

--- a/server/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/bsp/managers/BazelToolchainManager.kt
+++ b/server/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/bsp/managers/BazelToolchainManager.kt
@@ -3,18 +3,19 @@ package org.jetbrains.bsp.bazel.server.bsp.managers
 import org.eclipse.lsp4j.jsonrpc.CancelChecker
 import org.jetbrains.bazel.commons.label.Label
 import org.jetbrains.bsp.bazel.bazelrunner.BazelRunner
+import org.jetbrains.bsp.bazel.server.bsp.managers.Language
 import org.jetbrains.bsp.protocol.FeatureFlags
 
 class BazelToolchainManager(private val bazelRunner: BazelRunner, private val featureFlags: FeatureFlags) {
-  fun getToolchain(ruleLanguage: RuleLanguage, cancelChecker: CancelChecker): Label? =
+  fun getToolchain(ruleLanguage: RuleLanguage, cancelChecker: CancelChecker): List<Label> =
     when (ruleLanguage.language) {
-      Language.Scala -> Label.parse("@io_bazel_rules_scala//scala:toolchain_type")
-      Language.Java -> Label.parse("@bazel_tools//tools/jdk:runtime_toolchain_type")
-      Language.Kotlin -> Label.parse("@${ruleLanguage.ruleName}//kotlin/internal:kt_toolchain_type")
-      Language.Rust -> Label.parse("@${ruleLanguage.ruleName}//rust:toolchain_type")
+      Language.Scala -> listOf(Label.parse("@io_bazel_rules_scala//scala:toolchain_type"), Label.parse("@rules_scala_annex//rules/scala:toolchain_type"))
+      Language.Java -> listOf(Label.parse("@bazel_tools//tools/jdk:runtime_toolchain_type"))
+      Language.Kotlin -> listOf(Label.parse("@${ruleLanguage.ruleName}//kotlin/internal:kt_toolchain_type"))
+      Language.Rust -> listOf(Label.parse("@${ruleLanguage.ruleName}//rust:toolchain_type"))
       Language.Android -> getAndroidToolchain(ruleLanguage, cancelChecker)
-      Language.Go -> Label.parse("@${ruleLanguage.ruleName}//go:toolchain")
-      else -> null
+      Language.Go -> listOf(Label.parse("@${ruleLanguage.ruleName}//go:toolchain"))
+      else -> emptyList()
     }
 
   /**
@@ -22,9 +23,9 @@ class BazelToolchainManager(private val bazelRunner: BazelRunner, private val fe
    * However, starlarkified Android rules (`rules_android`, `build_bazel_rules_android`) can use either the built-in toolchain
    * or `@rules_android//toolchains/android_sdk:toolchain_type` depending on the version.
    */
-  fun getAndroidToolchain(ruleLanguage: RuleLanguage, cancelChecker: CancelChecker): Label? {
-    if (!featureFlags.isAndroidSupportEnabled) return null
-    if (ruleLanguage.ruleName == null) return NATIVE_ANDROID_TOOLCHAIN
+  fun getAndroidToolchain(ruleLanguage: RuleLanguage, cancelChecker: CancelChecker): List<Label> {
+    if (!featureFlags.isAndroidSupportEnabled) return emptyList()
+    if (ruleLanguage.ruleName == null) return listOf(NATIVE_ANDROID_TOOLCHAIN)
     val androidToolchain = Label.parse("@${ruleLanguage.ruleName}//toolchains/android_sdk:toolchain_type")
     val androidToolchainExists =
       bazelRunner.run {
@@ -38,7 +39,7 @@ class BazelToolchainManager(private val bazelRunner: BazelRunner, private val fe
           .waitAndGetResult(cancelChecker)
           .isSuccess
       }
-    return if (androidToolchainExists) androidToolchain else NATIVE_ANDROID_TOOLCHAIN
+    return listOf(if (androidToolchainExists) androidToolchain else NATIVE_ANDROID_TOOLCHAIN).filterNotNull()
   }
 
   companion object {

--- a/server/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/sync/languages/java/JavaLanguagePlugin.kt
+++ b/server/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/sync/languages/java/JavaLanguagePlugin.kt
@@ -1,8 +1,11 @@
 package org.jetbrains.bsp.bazel.server.sync.languages.java
 
+import org.jetbrains.bazel.commons.label.Label
 import ch.epfl.scala.bsp4j.BuildTarget
 import ch.epfl.scala.bsp4j.BuildTargetDataKind
 import ch.epfl.scala.bsp4j.JvmBuildTarget
+import org.jetbrains.bsp.bazel.info.BspTargetInfo.FileLocation
+import org.jetbrains.bsp.bazel.info.BspTargetInfo.JvmOutputsOrBuilder
 import org.jetbrains.bsp.bazel.info.BspTargetInfo.JvmTargetInfo
 import org.jetbrains.bsp.bazel.info.BspTargetInfo.TargetInfo
 import org.jetbrains.bsp.bazel.server.dependencygraph.DependencyGraph
@@ -53,7 +56,23 @@ class JavaLanguagePlugin(
   private fun getJdk(): Jdk = jdk ?: throw RuntimeException("Failed to resolve JDK for project")
 
   override fun dependencySources(targetInfo: TargetInfo, dependencyGraph: DependencyGraph): Set<URI> =
-    emptySet() // Provided via workspace/libraries
+    targetInfo.getJvmTargetInfoOrNull()?.run {
+      dependencyGraph
+        .transitiveDependenciesWithoutRootTargets(Label.parse(targetInfo.id))
+        .flatMap(::getSourceJars)
+        .map(bazelPathsResolver::resolveUri)
+        .toSet()
+    }.orEmpty()
+
+  private fun getSourceJars(targetInfo: TargetInfo): List<FileLocation> =
+    targetInfo
+      .getJvmTargetInfoOrNull()
+      ?.run { jarsOrBuilderList + generatedJarsList }
+      ?.flatMap(JvmOutputsOrBuilder::getSourceJarsList)
+      .orEmpty()
+
+  private fun TargetInfo.getJvmTargetInfoOrNull(): JvmTargetInfo? =
+    this.takeIf(TargetInfo::hasJvmTargetInfo)?.jvmTargetInfo
 
   override fun applyModuleData(moduleData: JavaModule, buildTarget: BuildTarget) {
     val jvmBuildTarget = toJvmBuildTarget(moduleData)

--- a/server/server/src/test/kotlin/org/jetbrains/bsp/bazel/server/bsp/managers/BazelBspLanguageExtensionsGeneratorTest.kt
+++ b/server/server/src/test/kotlin/org/jetbrains/bsp/bazel/server/bsp/managers/BazelBspLanguageExtensionsGeneratorTest.kt
@@ -61,7 +61,7 @@ class BazelBspLanguageExtensionsGeneratorTest {
             load("//aspects:rules/scala/scala_info.bzl","extract_scala_info")
             load("//aspects:rules/go/go_info.bzl","extract_go_info")
             EXTENSIONS=[extract_java_toolchain,extract_java_runtime,extract_jvm_info,extract_python_info,extract_cpp_info,extract_c_toolchain_info,extract_kotlin_info,extract_scala_info,extract_go_info]
-            TOOLCHAINS=["@bazel_tools//tools/jdk:runtime_toolchain_type","@io_bazel_rules_kotlin//kotlin/internal:kt_toolchain_type","@io_bazel_rules_scala//scala:toolchain_type","@io_bazel_rules_go//go:toolchain"]
+            TOOLCHAINS=["@bazel_tools//tools/jdk:runtime_toolchain_type","@io_bazel_rules_kotlin//kotlin/internal:kt_toolchain_type","@io_bazel_rules_scala//scala:toolchain_type","@rules_scala_annex//rules/scala:toolchain_type","@io_bazel_rules_go//go:toolchain"]
         """.replace(" ", "").replace("\n", "")
   private val defaultRuleLanguages =
     listOf(
@@ -71,10 +71,10 @@ class BazelBspLanguageExtensionsGeneratorTest {
     )
   private val defaultToolchains =
     mapOf(
-      RuleLanguage(null, Language.Java) to Label.parse("@bazel_tools//tools/jdk:runtime_toolchain_type"),
-      RuleLanguage("io_bazel_rules_kotlin", Language.Kotlin) to Label.parse("@io_bazel_rules_kotlin//kotlin/internal:kt_toolchain_type"),
-      RuleLanguage("io_bazel_rules_scala", Language.Scala) to Label.parse("@io_bazel_rules_scala//scala:toolchain_type"),
-      RuleLanguage("io_bazel_rules_go", Language.Go) to Label.parse("@io_bazel_rules_go//go:toolchain"),
+      RuleLanguage(null, Language.Java) to listOf(Label.parse("@bazel_tools//tools/jdk:runtime_toolchain_type")),
+      RuleLanguage("io_bazel_rules_kotlin", Language.Kotlin) to listOf(Label.parse("@io_bazel_rules_kotlin//kotlin/internal:kt_toolchain_type")),
+      RuleLanguage("io_bazel_rules_scala", Language.Scala) to listOf(Label.parse("@io_bazel_rules_scala//scala:toolchain_type"), Label.parse("@rules_scala_annex//rules/scala:toolchain_type")),
+      RuleLanguage("io_bazel_rules_go", Language.Go) to listOf(Label.parse("@io_bazel_rules_go//go:toolchain")),
     )
   private lateinit var dotBazelBspAspectsPath: Path
   private lateinit var internalAspectsResolverMock: InternalAspectsResolver


### PR DESCRIPTION
This should make it possible to run bazel-bsp with metals on projects that rely on lucidsoftware's fork of rules_scala. The main changes are:
- Tweaked the scala_info aspect and related code to support rules_scala
- Restored the dependencySources build server protocol feature (because metals is still using it)
- Added the `--norun_validations` flag to the aspect run to avoid accidentally pulling in slower actions as a part of the aspect run

As a note, I have tried running metals + bazel-bsp against a few different open source scala projects that were using bazel_io_rules_scala, and I couldn't get any of them to work. I did my best to "do no harm" with these changes if people are using this successfully, but if someone can provide me with steps to get a working setup, I'd appreciate any pointers. 